### PR TITLE
Update README, write trycopy output compressed and in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+.idea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # pg-recovery-tools
 Small utilities I have used for recovering corruption
+
+## trycopy.py
+
+This queries for the page count for a table. It then iterates over the pages in batches. For each page ctids are computed. Then for each ctid batch the `COPY` command is run. If that COPY succeeds the output is written, this is standard output from `COPY`. If the `COPY` fails because a ctid could not be read, the process then breaks the batch of ctids into tenths and tries that smaller batch; this breakdown recurses until the process is operating on single ctids. Finally if the operation fails on a single ctid that failure is logged and optionally written to a CSV file.
+
+The outcome is a row-by-row read of the table to recover as much data as possible. For the rows that could not be read, there is a log (or optional CSV) of what those failed ctids were.
+
+## crc32.py
+
+## xlogfilter.py
+
+xlogfilter is for when xlog replay fails with some error on some specific
+table or index, but you want to finish recovery on the rest of the database.
+
+## shiftcorruption.py
+shiftcorruption is for a really specific case of corruption where extra
+bytes have been inserted into database files moving the rest of the file
+forward.

--- a/trycopy.py
+++ b/trycopy.py
@@ -150,7 +150,7 @@ for start in xrange(start_page, total_pages, default_page_range):
     end = min(total_pages, start + default_page_range)
     log.warn("Start processing pages in batch from %i to %i", start, end)
     #the file name gets incremented with the batch count
-    #TODO can/should this be gzipped?
+    #gzip compression should generally work well with the output from COPY
     fd = gzip.open(compute_filename(outfilebasepath, start, end, tablename), "w", 9)
     ctids = ['"(%s,%s)"' % (pg, line) for pg in xrange(start, end) for line in xrange(max_linepointers_per_page)]
     copy_range(ctids)

--- a/trycopy.py
+++ b/trycopy.py
@@ -3,6 +3,9 @@ import logging
 import sys
 import time
 import gzip
+
+from math import floor, ceil
+
 try:
     from StringIO import StringIO ## for Python 2
 except ImportError:
@@ -126,7 +129,8 @@ def copy_range(ctids):
                     logging.warning("Refreshing DB connection after rollback attempt")
                     new_connection()
             if len(ctids) > 1:
-                batch_size = max(1, len(ctids) / 10)
+                #divide into tenths rounded up
+                batch_size = ceil(max(1, len(ctids) / 10))
                 log.info("Query error encountered: %s, bisecting into batches of %d" % (e, batch_size))
                 for start in range(0, len(ctids), batch_size):
                     copy_range(ctids[start:start + batch_size])

--- a/trycopy.py
+++ b/trycopy.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import sys
 import time
+import gzip
 from cStringIO import StringIO
 from optparse import OptionParser
 
@@ -150,7 +151,7 @@ for start in xrange(start_page, total_pages, default_page_range):
     log.warn("Start processing pages in batch from %i to %i", start, end)
     #the file name gets incremented with the batch count
     #TODO can/should this be gzipped?
-    fd = open(compute_filename(outfilebasepath, start, end, tablename), "w")
+    fd = gzip.open(compute_filename(outfilebasepath, start, end, tablename), "w", 9)
     ctids = ['"(%s,%s)"' % (pg, line) for pg in xrange(start, end) for line in xrange(max_linepointers_per_page)]
     copy_range(ctids)
     #is this flush and close necessary?

--- a/trycopy.py
+++ b/trycopy.py
@@ -91,7 +91,7 @@ log.warn("Processing relation %s", tablename)
 
 # given a base path, the start and end page counts, returns a string that is the file name to write to
 def compute_filename(base_path, start, end, table_name):
-    return "%s/%s.trycopy.%s-to-%s.out" % (base_path, table_name, start, end)
+    return "%s/%s.trycopy.%s-to-%s.out.gz" % (base_path, table_name, start, end)
 
 
 def copy_range(ctids):


### PR DESCRIPTION
1. I updated the README. Skimming the scripts makes it pretty easy to see what they do but a few sentences in the README will help newer users (like me!)
2. I altered trycopy to suit my own needs.
    1. Added more logging - I want it to log something whenever it hits any error condition, even errors it can recover from
    2. I write each batch out to its own file - I have a case where I am recovering data from a large (1.6TB) table with limited free disk space and non-technical challenges to getting more disk. Therefore having files split per batch helps me guard that space
    3. Add a "start at page" option - This is related to the space. If I run an extraction and have to stop it for some reason or it fails, this option lets me restart at a specific point and avoid having to start over
   4. gzip compression of the output files - the nature of my data compresses VERY well, I'm getting about 8x compression

I tested this script by:
* reading the gzip output with common utilities like zcat and zless
* starting with a higher page number and asserting that the script started at that page and not a lower page
* observing logs as it ran
* running a portion of the extract I need to manage
